### PR TITLE
Add fallback for the "city" field, in case "location" is empty.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ function parsePlace (place) {
   var result = {
     streetNumber: placeGet('street_number'),
     streetName: placeGet('route'),
-    city: placeGet('locality'),
+    city: placeGet('locality')
+      || placeGet('sublocality')
+      || placeGet('administrative_area_level_3')
+      || placeGet('administrative_area_level_2'),
     county: placeGet('administrative_area_level_2'),
     stateShort: placeGet('administrative_area_level_1', true),
     stateLong: placeGet('administrative_area_level_1'),


### PR DESCRIPTION
This logic is in accordance to geocoder's ruby library
https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/results/google.rb#L20-L30