### PR TITLE
Add "neighborhood" as city fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function parsePlace (place) {
     city: placeGet('locality') ||
       placeGet('sublocality') ||
       placeGet('sublocality_level_1') ||
+      placeGet('neighborhood') ||
       placeGet('administrative_area_level_3') ||
       placeGet('administrative_area_level_2'),
     county: placeGet('administrative_area_level_2'),

--- a/test.js
+++ b/test.js
@@ -44,15 +44,21 @@ test('city fallbacks', (t) => {
   t.equal(parseGooglePlace({
     address_components: [{
       long_name: 'Town3',
-      types: ['administrative_area_level_3']
+      types: ['neighborhood']
     }]
   }).city, 'Town3')
   t.equal(parseGooglePlace({
     address_components: [{
       long_name: 'Town4',
-      types: ['administrative_area_level_2']
+      types: ['administrative_area_level_3']
     }]
   }).city, 'Town4')
+  t.equal(parseGooglePlace({
+    address_components: [{
+      long_name: 'Town5',
+      types: ['administrative_area_level_2']
+    }]
+  }).city, 'Town5')
 
   t.end()
 })


### PR DESCRIPTION
Added "neighborhood" as another city fallback.

In my tests, I've seen locality > neighborhood > administrative_area_level_3 as a good priority fall-through, which is why I've slotted it where I did.

[Example response that shows need for neighborhood](https://pastebin.com/MGr0SAkX)