### PR TITLE
See #4, perfect address format

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ function parsePlace (place) {
     zipCode: placeGet('postal_code')
   }
 
-  result.address =
-    result.streetNumber +
-    (result.streetNumber && result.streetName ? ' ' : '') +
+  result.address [
+    result.streetNumber,
     result.streetName
-
+  ].filter(Boolean).join(' ')
+  
   return result
 
   function placeGet (key, short) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ function parsePlace (place) {
     zipCode: placeGet('postal_code')
   }
 
-  result.address = result.streetNumber + ' ' + result.streetName
+  result.address =
+    result.streetNumber +
+    (result.streetNumber && result.streetName ? ' ' : '') +
+    result.streetName
 
   return result
 


### PR DESCRIPTION
The address is ` ` when the `streetNumber` and `streetName` are both empty but expecting it to be an empty string

```js
result.address = result.streetNumber + ' ' + result.streetName
```